### PR TITLE
Add quotes around namespace and event

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ Logger.prototype = {
   },
 
   _getPrefix: function(event) {
-    return 'type=' + this.namespace + ' event=' + event;
+    return 'type="' + this.namespace + '" event="' + event + '""';
   },
 
   _prepareData: function(data) {

--- a/index.spec.coffee
+++ b/index.spec.coffee
@@ -20,8 +20,8 @@ describe "Logger", ->
       describe "#" + logFunction, ->
         it "should log the namespace and the given event name", ->
           logger[logFunction] "test"
-          expect(debugSpy).to.have.been.calledWithMatch /type=testnamespace/
-          expect(debugSpy).to.have.been.calledWithMatch /event=test/
+          expect(debugSpy).to.have.been.calledWithMatch /type="testnamespace"/
+          expect(debugSpy).to.have.been.calledWithMatch /event="test"/
 
         it "should log the given object properties as log property", ->
           logger[logFunction] "test", { par: 1, opar: 2 }
@@ -32,8 +32,8 @@ describe "Logger", ->
       describe "#" + logFunction, ->
         it "should log the namespace and the given event name", ->
           logger[logFunction] "test", "tData"
-          expect(debugSpy).to.have.been.calledWithMatch /type=testnamespace/
-          expect(debugSpy).to.have.been.calledWithMatch /event=test/
+          expect(debugSpy).to.have.been.calledWithMatch /type="testnamespace"/
+          expect(debugSpy).to.have.been.calledWithMatch /event="test"/
 
         it "should log the error message", ->
           logger[logFunction] "test", "emessage"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logentries-logformat",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "description": "Logformatter for logentries",
   "main": "./index.js",
   "scripts": {


### PR DESCRIPTION
Previously it was not possible to use "special character" in namespaces or events. Now the library correctly quotes these fields as well.
